### PR TITLE
add fail job lines

### DIFF
--- a/array-job/hyperparameter_tuning.py
+++ b/array-job/hyperparameter_tuning.py
@@ -25,6 +25,10 @@ def main():
     hyperparameters = read_hyperparameters(args.task_id,
                                            'hyperparameters.csv')
 
+    # Uncomment next two lines to test requeue for failed array jobs  
+    #if args.task_id %3 == 0:
+    #    raise ValueError()
+
     if hyperparameters is not None:
         # Write the hyperparameters to an output file
         output_file = f'output_{args.task_id}.txt'


### PR DESCRIPTION
added two lines to test failed array jobs. 

requeue failed jobs by

```bash
job_id=<ENTER JOB ID>;for i in $(sacct -j $job_id | grep FAILED | grep -v batch | awk '{ print $1 }'); do scontrol requeue $i; done
```

or 

```bash
job_id=<ENTER JOB ID>;for i in $(squeue -j $job_id --array --states=FAILED | awk 'NR > 1 { print $1 }'); do scontrol requeue $i; done
```